### PR TITLE
Feature/track cache hits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "firebase": "^10.3.1",
-                "next": "13.2.4",
+                "next": "^13.4.19",
                 "react": "18.2.0",
                 "react-dom": "18.2.0",
                 "recharts": "^2.5.0",
@@ -657,9 +657,9 @@
             "dev": true
         },
         "node_modules/@next/env": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-            "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+            "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "13.2.4",
@@ -670,40 +670,10 @@
                 "glob": "7.1.7"
             }
         },
-        "node_modules/@next/swc-android-arm-eabi": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-            "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-android-arm64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-            "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-            "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+            "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
             "cpu": [
                 "arm64"
             ],
@@ -716,9 +686,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-            "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+            "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
             "cpu": [
                 "x64"
             ],
@@ -730,40 +700,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@next/swc-freebsd-x64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-            "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@next/swc-linux-arm-gnueabihf": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-            "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-            "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+            "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
             "cpu": [
                 "arm64"
             ],
@@ -776,9 +716,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-            "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+            "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
             "cpu": [
                 "arm64"
             ],
@@ -791,9 +731,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-            "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+            "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
             "cpu": [
                 "x64"
             ],
@@ -806,9 +746,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-            "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+            "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
             "cpu": [
                 "x64"
             ],
@@ -821,9 +761,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-            "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+            "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
             "cpu": [
                 "arm64"
             ],
@@ -836,9 +776,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-            "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+            "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
             "cpu": [
                 "ia32"
             ],
@@ -851,9 +791,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-            "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+            "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
             "cpu": [
                 "x64"
             ],
@@ -981,9 +921,9 @@
             "dev": true
         },
         "node_modules/@swc/helpers": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-            "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1412,6 +1352,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
             }
         },
         "node_modules/call-bind": {
@@ -2658,6 +2609,11 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+        },
         "node_modules/globals": {
             "version": "13.20.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -2735,8 +2691,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/grapheme-splitter": {
             "version": "1.0.4",
@@ -3470,53 +3425,44 @@
             "dev": true
         },
         "node_modules/next": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-            "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+            "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
             "dependencies": {
-                "@next/env": "13.2.4",
-                "@swc/helpers": "0.4.14",
+                "@next/env": "13.4.19",
+                "@swc/helpers": "0.5.1",
+                "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
                 "postcss": "8.4.14",
-                "styled-jsx": "5.1.1"
+                "styled-jsx": "5.1.1",
+                "watchpack": "2.4.0",
+                "zod": "3.21.4"
             },
             "bin": {
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=14.6.0"
+                "node": ">=16.8.0"
             },
             "optionalDependencies": {
-                "@next/swc-android-arm-eabi": "13.2.4",
-                "@next/swc-android-arm64": "13.2.4",
-                "@next/swc-darwin-arm64": "13.2.4",
-                "@next/swc-darwin-x64": "13.2.4",
-                "@next/swc-freebsd-x64": "13.2.4",
-                "@next/swc-linux-arm-gnueabihf": "13.2.4",
-                "@next/swc-linux-arm64-gnu": "13.2.4",
-                "@next/swc-linux-arm64-musl": "13.2.4",
-                "@next/swc-linux-x64-gnu": "13.2.4",
-                "@next/swc-linux-x64-musl": "13.2.4",
-                "@next/swc-win32-arm64-msvc": "13.2.4",
-                "@next/swc-win32-ia32-msvc": "13.2.4",
-                "@next/swc-win32-x64-msvc": "13.2.4"
+                "@next/swc-darwin-arm64": "13.4.19",
+                "@next/swc-darwin-x64": "13.4.19",
+                "@next/swc-linux-arm64-gnu": "13.4.19",
+                "@next/swc-linux-arm64-musl": "13.4.19",
+                "@next/swc-linux-x64-gnu": "13.4.19",
+                "@next/swc-linux-x64-musl": "13.4.19",
+                "@next/swc-win32-arm64-msvc": "13.4.19",
+                "@next/swc-win32-ia32-msvc": "13.4.19",
+                "@next/swc-win32-x64-msvc": "13.4.19"
             },
             "peerDependencies": {
-                "@opentelemetry/api": "^1.4.0",
-                "fibers": ">= 3.1.0",
-                "node-sass": "^6.0.0 || ^7.0.0",
+                "@opentelemetry/api": "^1.1.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
                 "@opentelemetry/api": {
-                    "optional": true
-                },
-                "fibers": {
-                    "optional": true
-                },
-                "node-sass": {
                     "optional": true
                 },
                 "sass": {
@@ -4246,6 +4192,14 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4596,6 +4550,18 @@
                 "d3-shape": "^3.1.0",
                 "d3-time": "^3.0.0",
                 "d3-timer": "^3.0.1"
+            }
+        },
+        "node_modules/watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
             }
         },
         "node_modules/webidl-conversions": {
@@ -5296,9 +5262,9 @@
             "dev": true
         },
         "@next/env": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.2.4.tgz",
-            "integrity": "sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA=="
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
+            "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
         },
         "@next/eslint-plugin-next": {
             "version": "13.2.4",
@@ -5309,82 +5275,58 @@
                 "glob": "7.1.7"
             }
         },
-        "@next/swc-android-arm-eabi": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-            "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-            "optional": true
-        },
-        "@next/swc-android-arm64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-            "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-            "optional": true
-        },
         "@next/swc-darwin-arm64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.2.4.tgz",
-            "integrity": "sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
+            "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.2.4.tgz",
-            "integrity": "sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==",
-            "optional": true
-        },
-        "@next/swc-freebsd-x64": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-            "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-            "optional": true
-        },
-        "@next/swc-linux-arm-gnueabihf": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-            "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
+            "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.2.4.tgz",
-            "integrity": "sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
+            "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.2.4.tgz",
-            "integrity": "sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
+            "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.2.4.tgz",
-            "integrity": "sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
+            "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.2.4.tgz",
-            "integrity": "sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
+            "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.2.4.tgz",
-            "integrity": "sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
+            "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.2.4.tgz",
-            "integrity": "sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
+            "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.2.4.tgz",
-            "integrity": "sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
+            "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
             "optional": true
         },
         "@nodelib/fs.scandir": {
@@ -5488,9 +5430,9 @@
             "dev": true
         },
         "@swc/helpers": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-            "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
             "requires": {
                 "tslib": "^2.4.0"
             }
@@ -5814,6 +5756,14 @@
             "dev": true,
             "requires": {
                 "fill-range": "^7.0.1"
+            }
+        },
+        "busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "requires": {
+                "streamsearch": "^1.1.0"
             }
         },
         "call-bind": {
@@ -6774,6 +6724,11 @@
                 "is-glob": "^4.0.3"
             }
         },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+        },
         "globals": {
             "version": "13.20.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
@@ -6830,8 +6785,7 @@
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -7351,28 +7305,27 @@
             "dev": true
         },
         "next": {
-            "version": "13.2.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.2.4.tgz",
-            "integrity": "sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==",
+            "version": "13.4.19",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
+            "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
             "requires": {
-                "@next/env": "13.2.4",
-                "@next/swc-android-arm-eabi": "13.2.4",
-                "@next/swc-android-arm64": "13.2.4",
-                "@next/swc-darwin-arm64": "13.2.4",
-                "@next/swc-darwin-x64": "13.2.4",
-                "@next/swc-freebsd-x64": "13.2.4",
-                "@next/swc-linux-arm-gnueabihf": "13.2.4",
-                "@next/swc-linux-arm64-gnu": "13.2.4",
-                "@next/swc-linux-arm64-musl": "13.2.4",
-                "@next/swc-linux-x64-gnu": "13.2.4",
-                "@next/swc-linux-x64-musl": "13.2.4",
-                "@next/swc-win32-arm64-msvc": "13.2.4",
-                "@next/swc-win32-ia32-msvc": "13.2.4",
-                "@next/swc-win32-x64-msvc": "13.2.4",
-                "@swc/helpers": "0.4.14",
+                "@next/env": "13.4.19",
+                "@next/swc-darwin-arm64": "13.4.19",
+                "@next/swc-darwin-x64": "13.4.19",
+                "@next/swc-linux-arm64-gnu": "13.4.19",
+                "@next/swc-linux-arm64-musl": "13.4.19",
+                "@next/swc-linux-x64-gnu": "13.4.19",
+                "@next/swc-linux-x64-musl": "13.4.19",
+                "@next/swc-win32-arm64-msvc": "13.4.19",
+                "@next/swc-win32-ia32-msvc": "13.4.19",
+                "@next/swc-win32-x64-msvc": "13.4.19",
+                "@swc/helpers": "0.5.1",
+                "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
                 "postcss": "8.4.14",
-                "styled-jsx": "5.1.1"
+                "styled-jsx": "5.1.1",
+                "watchpack": "2.4.0",
+                "zod": "3.21.4"
             }
         },
         "node-fetch": {
@@ -7858,6 +7811,11 @@
                 "internal-slot": "^1.0.4"
             }
         },
+        "streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+        },
         "string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8119,6 +8077,15 @@
                 "d3-shape": "^3.1.0",
                 "d3-time": "^3.0.0",
                 "d3-timer": "^3.0.1"
+            }
+        },
+        "watchpack": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+            "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
             }
         },
         "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "firebase": "^10.3.1",
-        "next": "13.2.4",
+        "next": "^13.4.19",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "recharts": "^2.5.0",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { MetricsService } from './services/MetricsService';
 
 export function middleware(request: NextRequest): NextResponse {
     const response = NextResponse.next();
 
     // Cache hit
     if (response.status === 304) {
-        // TODO: Log cache hit
+        const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
+        MetricsService.logCachedContributionsRequest(username);
     }
 
     return response;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function middleware(request: NextRequest): Promise<NextResponse> {
     const response = NextResponse.next();
 
+    console.log(response.redirected);
     if (response.status === 304) {
         await logCacheHit(request);
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-export function middleware(request: NextRequest): NextResponse {
+export async function middleware(request: NextRequest): Promise<NextResponse> {
     const response = NextResponse.next();
 
     if (response.status === 304) {
-        logCacheHit(request);
+        await logCacheHit(request);
     }
 
     return response;
@@ -15,7 +15,7 @@ async function logCacheHit(request: NextRequest): Promise<void> {
     const { MetricsService } = await import('@/services/MetricsService');
 
     const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
-    MetricsService.logCachedContributionsRequest(username);
+    await MetricsService.logCachedContributionsRequest(username);
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { MetricsService } from './services/MetricsService';
 
 export function middleware(request: NextRequest): NextResponse {
     const response = NextResponse.next();
 
-    // Cache hit
     if (response.status === 304) {
-        const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
-        MetricsService.logCachedContributionsRequest(username);
+        logCacheHit(request);
     }
 
     return response;
+}
+
+async function logCacheHit(request: NextRequest): Promise<void> {
+    // Dynamically import Metric service so that it's not loaded unless needed
+    const { MetricsService } = await import('@/services/MetricsService');
+
+    const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
+    MetricsService.logCachedContributionsRequest(username);
 }
 
 export const config = {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,4 +20,5 @@ async function logCacheHit(request: NextRequest): Promise<void> {
 
 export const config = {
     matcher: '/api/contributions/:username*',
+    unstable_allowDynamic: ['/node_modules/@firebase/firestore/**'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,10 @@
-import { MetricsService } from '@/services/MetricsService';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
     const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
-    await MetricsService.logContributionRequest(username);
+
+    await fetch(new URL(`${request.nextUrl.origin}/api/metrics/${username}`).href);
+
     return NextResponse.next();
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest): NextResponse {
+    const response = NextResponse.next();
+
+    // Cache hit
+    if (response.status === 304) {
+        // TODO: Log cache hit
+    }
+
+    return response;
+}
+
+export const config = {
+    matcher: '/api/contributions/:username*',
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,22 +1,10 @@
+import { MetricsService } from '@/services/MetricsService';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
-    const response = NextResponse.next();
-
-    console.log(response.redirected);
-    if (response.status === 304) {
-        await logCacheHit(request);
-    }
-
-    return response;
-}
-
-async function logCacheHit(request: NextRequest): Promise<void> {
-    // Dynamically import Metric service so that it's not loaded unless needed
-    const { MetricsService } = await import('@/services/MetricsService');
-
     const username = request.nextUrl.pathname.substring('/api/contributions/'.length);
-    await MetricsService.logCachedContributionsRequest(username);
+    await MetricsService.logContributionRequest(username);
+    return NextResponse.next();
 }
 
 export const config = {

--- a/src/pages/api/contributions/[username].tsx
+++ b/src/pages/api/contributions/[username].tsx
@@ -52,7 +52,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 ${htmlWithoutDiv}
             </svg>`;
 
-        MetricsService.logContributionsRequest({ username, fetchingMs, chartRenderingMs });
+        await MetricsService.logContributionsRequest({ username, fetchingMs, chartRenderingMs });
 
         // Only allow vercel to cache the response.
         // See: https://vercel.com/docs/edge-network/caching#cdn-cache-control

--- a/src/pages/api/contributions/[username].tsx
+++ b/src/pages/api/contributions/[username].tsx
@@ -54,9 +54,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         MetricsService.logContributionsRequest({ username, fetchingMs, chartRenderingMs });
 
+        // Only allow vercel to cache the response.
+        // See: https://vercel.com/docs/edge-network/caching#cdn-cache-control
         res.status(200)
             .setHeader('Content-Type', 'image/svg+xml')
-            .setHeader('Cache-Control', `public, s-maxage=${CACHE_RESPONSE_SECONDS}`)
+            .setHeader('Vercel-CDN-Cache-Control', `public, s-maxage=${CACHE_RESPONSE_SECONDS}`)
             .send(svg);
     } catch (error) {
         ErrorService.handleError(res, error);

--- a/src/pages/api/contributions/[username].tsx
+++ b/src/pages/api/contributions/[username].tsx
@@ -52,7 +52,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 ${htmlWithoutDiv}
             </svg>`;
 
-        await MetricsService.logContributionsRequest({ username, fetchingMs, chartRenderingMs });
+        await MetricsService.logContributionResponse({ username, fetchingMs, chartRenderingMs });
 
         // Only allow vercel to cache the response.
         // See: https://vercel.com/docs/edge-network/caching#cdn-cache-control

--- a/src/pages/api/metrics/[username].tsx
+++ b/src/pages/api/metrics/[username].tsx
@@ -1,0 +1,18 @@
+import { ErrorService } from '@/services/ErrorService';
+import { MetricsService } from '@/services/MetricsService';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { z } from 'zod';
+
+const UsernameModel = z.object({ username: z.string() });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+    try {
+        const { username } = await UsernameModel.parseAsync(req.query);
+
+        await MetricsService.logContributionRequest(username);
+
+        res.status(204).end();
+    } catch (error) {
+        ErrorService.handleError(res, error);
+    }
+}

--- a/src/services/MetricsService.ts
+++ b/src/services/MetricsService.ts
@@ -1,39 +1,32 @@
 import { db } from '@/firebase';
-import ContributionMetric, {
-    CachedContributionMetric,
-    UncachedContributionMetric,
-} from '@/types/interfaces/ContributionMetric';
+import { ContributionRequestMetric, ContributionResponseMetric } from '@/types/interfaces/ContributionMetric';
 import { addDoc, collection } from 'firebase/firestore';
 
 export namespace MetricsService {
-    const githubContributionMetrics = collection(db, 'github_contribution_metrics');
+    const contributionRequestMetrics = collection(db, 'contribution_request_metrics');
+    const contributionResponseMetrics = collection(db, 'contribution_response_metrics');
 
-    export async function logContributionsRequest(
-        partialMetric: Omit<UncachedContributionMetric, 'date' | 'environment' | 'cacheHit'>,
+    export async function logContributionResponse(
+        partialMetric: Omit<ContributionResponseMetric, 'date' | 'environment'>,
     ): Promise<void> {
-        const metric: UncachedContributionMetric = {
+        const metric: ContributionResponseMetric = {
             ...partialMetric,
-            cacheHit: false,
             date: new Date(),
             environment: process.env.NODE_ENV,
         };
 
-        logMetric(metric);
+        const docRef = await addDoc(contributionResponseMetrics, metric);
+        console.log(`Logged contribution response for user '${metric.username}' with id: '${docRef.id}'.`);
     }
 
-    export async function logCachedContributionsRequest(username: string): Promise<void> {
-        const metric: CachedContributionMetric = {
+    export async function logContributionRequest(username: string): Promise<void> {
+        const metric: ContributionRequestMetric = {
             username,
-            cacheHit: true,
             date: new Date(),
             environment: process.env.NODE_ENV,
         };
 
-        logMetric(metric);
-    }
-
-    async function logMetric(metric: ContributionMetric) {
-        const docRef = await addDoc(githubContributionMetrics, metric);
-        console.log(`Logged contributions request for user '${metric.username}' with id: '${docRef.id}'.`);
+        const docRef = await addDoc(contributionRequestMetrics, metric);
+        console.log(`Logged contribution request for user '${metric.username}' with id: '${docRef.id}'.`);
     }
 }

--- a/src/services/MetricsService.ts
+++ b/src/services/MetricsService.ts
@@ -1,19 +1,38 @@
 import { db } from '@/firebase';
-import ContributionMetric from '@/types/interfaces/ContributionMetric';
+import ContributionMetric, {
+    CachedContributionMetric,
+    UncachedContributionMetric,
+} from '@/types/interfaces/ContributionMetric';
 import { addDoc, collection } from 'firebase/firestore';
 
 export namespace MetricsService {
     const githubContributionMetrics = collection(db, 'github_contribution_metrics');
 
     export async function logContributionsRequest(
-        partialMetric: Omit<ContributionMetric, 'date' | 'environment'>,
+        partialMetric: Omit<UncachedContributionMetric, 'date' | 'environment' | 'cacheHit'>,
     ): Promise<void> {
-        const metric: ContributionMetric = {
+        const metric: UncachedContributionMetric = {
             ...partialMetric,
+            cacheHit: false,
             date: new Date(),
             environment: process.env.NODE_ENV,
         };
 
+        logMetric(metric);
+    }
+
+    export async function logCachedContributionsRequest(username: string): Promise<void> {
+        const metric: CachedContributionMetric = {
+            username,
+            cacheHit: true,
+            date: new Date(),
+            environment: process.env.NODE_ENV,
+        };
+
+        logMetric(metric);
+    }
+
+    async function logMetric(metric: ContributionMetric) {
         const docRef = await addDoc(githubContributionMetrics, metric);
         console.log(`Logged contributions request for user '${metric.username}' with id: '${docRef.id}'.`);
     }

--- a/src/types/interfaces/ContributionMetric.ts
+++ b/src/types/interfaces/ContributionMetric.ts
@@ -1,18 +1,10 @@
-export interface CommonContributionMetric {
+export interface ContributionRequestMetric {
     username: string;
     date: Date;
     environment: string;
 }
 
-export interface CachedContributionMetric extends CommonContributionMetric {
-    cacheHit: true;
-}
-
-export interface UncachedContributionMetric extends CommonContributionMetric {
-    cacheHit: false;
+export interface ContributionResponseMetric extends ContributionRequestMetric {
     fetchingMs: number;
     chartRenderingMs: number;
 }
-
-type ContributionMetric = CachedContributionMetric | UncachedContributionMetric;
-export default ContributionMetric;

--- a/src/types/interfaces/ContributionMetric.ts
+++ b/src/types/interfaces/ContributionMetric.ts
@@ -1,7 +1,18 @@
-export default interface ContributionMetric {
+export interface CommonContributionMetric {
     username: string;
     date: Date;
     environment: string;
+}
+
+export interface CachedContributionMetric extends CommonContributionMetric {
+    cacheHit: true;
+}
+
+export interface UncachedContributionMetric extends CommonContributionMetric {
+    cacheHit: false;
     fetchingMs: number;
     chartRenderingMs: number;
 }
+
+type ContributionMetric = CachedContributionMetric | UncachedContributionMetric;
+export default ContributionMetric;


### PR DESCRIPTION
Closes #27 

So this has been an absolute nightmare:
* It turns out NextJS middleware can only be used to write information to responses, meaning there's no way to tell if a response was a cache hit or not (Such as by inspecting the status code for 304).
* I then decided to create two sets of metrics — requests and responses. This way, the cache hits can be inferred by looking at all the requests that don't have corresponding response metrics. The request metrics would be made in the middleware as this is always run regardless of a cache hit and response metrics would be done in the actual endpoint, meaning they don't run on a cache hit.
* Unfortunately, NextJS middleware doesn't have access to the `XMLHttpRequest` required by firebase to make requests, which caused internal server errors.
* Trying to use a polyfill such as xhr2 to add this back to the global scope simply didn't work for some reason and neither did trying different runtimes for the middleware (E.g. `edge` and `nextjs`).
* I tried to create a `POST /api/metrics` endpoint that could be `fetch`-ed from in the middleware to handle the firebase request as this actually works on the serverless functions NextJS uses to run API endpoints.
* After finally managing to get the `fetch` working, it turns out that this skips all the middleware usually called for requests to a NextJS endpoint and so the request body was not deserialized into an object! (It was still stringified :sob:).
* This led me to my final — slightly rough — solution of only doing the request metrics in a `/api/metrics/[username]` endpoint as only a username is required and it can be specified in the URL... The response metrics can be done normally in the `/api/contributions/[username]` endpoint.

I am now concerned the 2 additional layers (Middleware and metrics endpoint) will cause the endpoint to take too long from a cold boot to actually return a response in time for GitHub...