### PR TITLE
Feature/cache time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Query Parameter | Description             | Type    | Default Value
 `area`          | Whether to shade the area under the curve | `true` or `false` | `true`
 `width`         | The width of the SVG in pixels  | Positive number | `1200`
 `height`        | The height of the SVG in pixels | Positive number | `450`
-`cache`         | The time in seconds a contribution graph can be cached for. This is not done by the API, but instead utilises the `Cache-Control` header which the GitHub CDN uses to do the actual caching. A value of 0 can be used to disable caching of the response | Positive number | `300` (5 Minutes)
+`cache`         | The time in seconds a contribution graph can be cached for. A value of 0 can be used to disable caching of the response | Positive number | `300` (5 Minutes)
 
 An example using some of these looks like:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Query Parameter | Description             | Type    | Default Value
 `area`          | Whether to shade the area under the curve | `true` or `false` | `true`
 `width`         | The width of the SVG in pixels  | Positive number | `1200`
 `height`        | The height of the SVG in pixels | Positive number | `450`
+`cache`         | The time in seconds a contribution graph can be cached for. This is not done by the API, but instead utilises the `Cache-Control` header which the GitHub CDN uses to do the actual caching. A value of 0 can be used to disable caching of the response | Positive number | `300` (5 Minutes)
 
 An example using some of these looks like:
 

--- a/src/models/Options.ts
+++ b/src/models/Options.ts
@@ -11,7 +11,7 @@ export const OptionsModel = z.object({
     to: z.coerce.date().optional(),
     days: z.coerce.number().positive().optional(),
     area: BooleanModel.optional(),
-    cache: z.number().positive().optional(),
+    cache: z.coerce.number().min(0).optional(),
 });
 
 export type Options = Required<z.infer<typeof OptionsModel>>;

--- a/src/models/Options.ts
+++ b/src/models/Options.ts
@@ -11,6 +11,7 @@ export const OptionsModel = z.object({
     to: z.coerce.date().optional(),
     days: z.coerce.number().positive().optional(),
     area: BooleanModel.optional(),
+    cache: z.number().positive().optional(),
 });
 
 export type Options = Required<z.infer<typeof OptionsModel>>;

--- a/src/pages/api/contributions/[username].tsx
+++ b/src/pages/api/contributions/[username].tsx
@@ -7,8 +7,6 @@ import { OptionsService } from '@/services/OptionsService';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { renderToString } from 'react-dom/server';
 
-const CACHE_RESPONSE_SECONDS = 60 * 5; // 5 minutes
-
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
     try {
         const { username, ...queryOptions } = await QueryParamsModel.parseAsync(req.query);
@@ -56,7 +54,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         res.status(200)
             .setHeader('Content-Type', 'image/svg+xml')
-            .setHeader('Cache-Control', `public, s-maxage=${CACHE_RESPONSE_SECONDS}`)
+            .setHeader('Cache-Control', `public, s-maxage=${options.cache}`)
             .send(svg);
     } catch (error) {
         ErrorService.handleError(res, error);

--- a/src/services/OptionsService.ts
+++ b/src/services/OptionsService.ts
@@ -12,6 +12,7 @@ export namespace OptionsService {
         height: 450,
         days: 30,
         area: true,
+        cache: 60 * 5, // 5 Minutes
     };
 
     const ONE_DAY = 1000 * 60 * 60 * 24;


### PR DESCRIPTION
Closes #32 

Adds a `cache` query parameter for controlling the cache time of a contribution chart.