### PR TITLE
Fix/cors blocking requests

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export function middleware(): NextResponse {
-    const res = NextResponse.next();
+export function middleware(req: NextRequest): Response {
+    const res = req.method === 'OPTIONS' ? new Response(undefined, { status: 204 }) : NextResponse.next();
 
     res.headers.append('Access-Control-Allow-Origin', '*');
     res.headers.append('Access-Control-Allow-Methods', 'GET');
-
     return res;
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(): NextResponse {
+    const res = NextResponse.next();
+
+    res.headers.append('Access-Control-Allow-Origin', '*');
+    res.headers.append('Access-Control-Allow-Methods', 'GET');
+
+    return res;
+}
+
+export const config = {
+    matcher: '/api/:path*', // Match all API routes
+};


### PR DESCRIPTION
Fixes #46.

Currently, an API-wide middleware has been applied that handles the CORS `OPTIONS` requests.

If at a later point, finer control is required, then this could be done by wrapping the endpoints in a CORS decorator. 