### PR TITLE
Use title variable

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,8 +28,8 @@ export default function Home() {
 
                 <meta property="og:title" content={Title} />
                 <meta property="og:type" content="website" />
-                {/* og:image doesn't support relative paths unfortunately... */}
-                <meta property="og:image" content={`${window.location.origin}/contributionsGraph.png`} />
+                {/* og:image doesn't support relative paths unfortunately and we don't have access to `window`...  */}
+                <meta property="og:image" content="https://github.pumbas.net/contributionsGraph.png" />
                 <meta property="og:url" content="https://github.pumbas.net" />
                 <meta name="twitter:card" content="summary_large_image" />
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,10 +26,10 @@ export default function Home() {
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 <link rel="icon" href="/favicon.ico" />
 
-                <meta property="og:title" content="GitHub Contributions Playground" />
+                <meta property="og:title" content={Title} />
                 <meta property="og:type" content="website" />
                 {/* og:image doesn't support relative paths unfortunately... */}
-                <meta property="og:image" content="https://github.pumbas.net/contributionsGraph.png" />
+                <meta property="og:image" content={`${window.location.origin}/contributionsGraph.png`} />
                 <meta property="og:url" content="https://github.pumbas.net" />
                 <meta name="twitter:card" content="summary_large_image" />
 


### PR DESCRIPTION
* Fixed a missing usage of thr `Title` variable.
* ~Makes it so that the `og:image` isn't completely hardcoded for the URL of the image.~ We can't access `window` as this is generated at build time...