### PR TITLE
ci: :construction: Fix npm command not being found in GH actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,4 @@ jobs:
                   key: ${{ secrets.SSH_KEY }}
                   script: |
                       cd services/github-contributions
-                      chmod +x scripts/deploy.sh
                       ./scripts/deploy.sh

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,13 +4,19 @@
 
 processName="github-contributions"
 
-# exit when any command fails
+# Exit when any command fails
 set -e
 
 git reset --hard --quiet
 
 echo "Pulling from origin"
 git pull --quiet
+
+# Ensure that npm can be found by GitHub actions
+# See: https://gist.github.com/danielwetan/4f4db933531db5dd1af2e69ec8d54d8a?permalink_comment_id=4057972
+echo "Setting up NVM"
+export NVM_DIR=~/.nvm
+source ~/.nvm/nvm.sh
 
 export NODE_ENV=production
 
@@ -21,7 +27,7 @@ echo "Building"
 npm run build
 
 echo "Killing old instance"
-# deletion is allowed to fail, since the process might not have been running previously
+# Deletion is allowed to fail, since the process might not have been running previously
 pm2 delete $processName --silent || true 
 
 echo "Starting new instance"


### PR DESCRIPTION
So it turns out that GitHub actions can't find npm because it's not installed in the usual location when using `nvm`. I've added some lines to the script which should hopefully fix that.